### PR TITLE
PROJ-238 Set school level as not required for Site

### DIFF
--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -32,7 +32,7 @@ class SchoolLevelSerializer(serializers.HyperlinkedModelSerializer):
 
 class SiteSerializer(serializers.HyperlinkedModelSerializer):
     school_level = serializers.PrimaryKeyRelatedField(
-        queryset=SchoolLevel.objects.all()
+        queryset=SchoolLevel.objects.all(), required=False, allow_null=True
     )
 
     class Meta:


### PR DESCRIPTION
In the accounts model, this is the only other relation that I think should not be a required field (eg. RSO doesn't have a school level).