### PR TITLE
Staging

### DIFF
--- a/high_health/views.py
+++ b/high_health/views.py
@@ -182,11 +182,12 @@ def monthly_data(metric_id, school_id):
     py_values = distinct_values(py_measures)
     months = distinct_months(py_measures, cy_measures)
     values = cy_values + py_values
+    non_null_values = list(filter(None, values))
     goal = Goal.objects.get(metric=metric_id, school=school_id)
     target = round(goal.target)
     goal_type = goal.goal_type
-    axis_min = find_axis_min(values, target)
-    axis_max = find_axis_max(values, target)
+    axis_min = find_axis_min(non_null_values, target)
+    axis_max = find_axis_max(non_null_values, target)
     goal_color = get_goal_color(goal, cy_values[-1])
 
     return {
@@ -211,11 +212,12 @@ def yearly_data(metric_id, school_id):
         "date"
     )
     values = distinct_values(measures)
+    non_null_values = list(filter(None, values))
     goal = Goal.objects.get(metric=metric_id, school=school_id)
     target = round(goal.target)
     goal_type = goal.goal_type
-    axis_min = find_axis_min(values, target)
-    axis_max = find_axis_max(values, target)
+    axis_min = find_axis_min(non_null_values, target)
+    axis_max = find_axis_max(non_null_values, target)
     goal_color = get_goal_color(goal, values[-1])
 
     return {

--- a/static/js/hh_chart_modal.js
+++ b/static/js/hh_chart_modal.js
@@ -12,6 +12,7 @@ $('.hh_value').click(function (event) {
                         label: response['data']['py_label'],
                         fill: false,
                         data: response['data']['previous_year'],
+                        spanGaps: true,
                         lineTension: 0,
                     }, {
                         label: response['data']['cy_label'],
@@ -19,6 +20,7 @@ $('.hh_value').click(function (event) {
                         borderColor: '#0071CE',
                         backgroundColor: '#0071CE',
                         data: response['data']['current_year'],
+                        spanGaps: true,
                         lineTension: 0,
                     }]
                 }
@@ -30,6 +32,7 @@ $('.hh_value').click(function (event) {
                         borderColor: '#0071CE',
                         backgroundColor: '#0071CE',
                         data: response['data']['values'],
+                        spanGaps: true,
                         lineTension: 0,
                     }]
                 }


### PR DESCRIPTION
Update the behavior of charts to allow them to display gaps (connected by a line) for null values. This change applies to both monthly and yearly metrics.

You can take a look in staging yourself with the Pulse connectedness metric for Bayview (the data is fake).