### PR TITLE
Bringing back "Priority"/Grey out % Staffed Metric

### DIFF
--- a/high_health/views.py
+++ b/high_health/views.py
@@ -177,7 +177,7 @@ def yoy_color_eval(goal, value):
         if value <= goal.target:
             return SUCCESS_COLOR
         elif goal.previous_outcome >= value > goal.target:
-           return SECONDARY_COLOR
+            return SECONDARY_COLOR
         else:
             return DANGER_COLOR
 

--- a/high_health/views.py
+++ b/high_health/views.py
@@ -182,7 +182,10 @@ def yoy_color_eval(goal, value):
             return DANGER_COLOR
 
 
-def mom_color_eval(goal, value, previous):
+def mom_color_eval(goal, value, previous, bypass=False):
+    if bypass:
+        return SECONDARY_COLOR
+
     if goal.goal_type.upper() == "ABOVE":
         if value < previous:
             return DANGER_COLOR
@@ -207,6 +210,7 @@ def get_last_years_value(month, measures):
     except IndexError:
         return None
 
+
 def monthly_data(metric_id, school_id):
     cy_measures = year_bound_measures(metric_id, school_id)
     py_measures = year_bound_measures(metric_id, school_id, previous_year=True)
@@ -225,7 +229,11 @@ def monthly_data(metric_id, school_id):
     current_month = cy_measures.reverse()[0].month
     last_year_value = get_last_years_value(current_month, py_measures)
 
-    goal_color = mom_color_eval(goal, cy_values[-1], last_year_value)
+    # temporary bypass of color eval of % Staffed metric
+    if metric_id == 36:
+        goal_color = mom_color_eval(goal, cy_values[-1], last_year_value, bypass=True)
+    else:
+        goal_color = mom_color_eval(goal, cy_values[-1], last_year_value)
 
     return {
         "frequency": "monthly",

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -20,6 +20,10 @@ h1 {
   font-weight: 300;
 }
 
+span[id="metric-hover"] {
+  cursor: pointer
+}
+
 .text-primary, a {
   color: var(--primary-color) !important;
 }

--- a/templates/high_health.html
+++ b/templates/high_health.html
@@ -42,7 +42,11 @@
           <td class="text-center eq" data-toggle="popover" data-trigger="hover"
             title="{{ metric.metric.essential_question }}"
             data-content="{{ metric.metric.essential_question.description }}">
-            {{ metric.metric.essential_question }}
+            {% if metric.metric.essential_question=="Priority" %}
+              P
+            {% else %}
+              -
+            {% end if %}
           </td>
           <td style="min-width:240px">
             <i class="fas fa-info-circle text-primary pl-1 metric-def" data-toggle="popover" data-trigger="hover"

--- a/templates/high_health.html
+++ b/templates/high_health.html
@@ -49,7 +49,7 @@
             <td class="text-center eq" title="None">
               --
             </td>
-          {% end if %}
+          {% endif %}
           <td style="min-width:240px">
             <i class="fas fa-info-circle text-primary pl-1 metric-def" data-toggle="popover" data-trigger="hover"
               title="{{ metric.metric }}" data-content="{{ metric.metric.definition }}"></i>

--- a/templates/high_health.html
+++ b/templates/high_health.html
@@ -39,7 +39,7 @@
       <tbody>
         {% for metric in metrics %}
         <tr>
-          {% if metric.metric.essential_question=="Priority" %}
+          {% if metric.metric.essential_question.name == "Priority" %}
             <td class="text-center eq" data-toggle="popover" data-trigger="hover"
               title="{{ metric.metric.essential_question }}"
               data-content="{{ metric.metric.essential_question.description }}">

--- a/templates/high_health.html
+++ b/templates/high_health.html
@@ -40,7 +40,7 @@
         {% for metric in metrics %}
         <tr>
           <td class="text-center eq" data-toggle="popover" data-trigger="hover"
-            title="{{ metric.metric.essential_question }}"
+            title="{% if metric.metric.essential_question.name == 'Priority' %}P{% else %} {% end if %}"
             data-content="{{ metric.metric.essential_question.description }}">
             {{ metric.metric.essential_question }}
           </td>

--- a/templates/high_health.html
+++ b/templates/high_health.html
@@ -40,7 +40,7 @@
         {% for metric in metrics %}
         <tr>
           <td class="text-center eq" data-toggle="popover" data-trigger="hover"
-            title="{% if metric.metric.essential_question.name == 'Priority' %}P{% else %} {% end if %}"
+            title="{{ metric.metric.essential_question }}"
             data-content="{{ metric.metric.essential_question.description }}">
             {{ metric.metric.essential_question }}
           </td>

--- a/templates/high_health.html
+++ b/templates/high_health.html
@@ -70,7 +70,7 @@
             {% with "chart_"|addstr:measure.metric.id|addstr:"_"|addstr:measure.school.id as chart_id %}
             <span data-toggle="modal" data-target="#{{ modal_id }}" class="hh_value text-{{ measure|goal_format }}"
               data-metric-id="{{ measure.metric.id }}" data-school-id="{{ measure.school.id }}">
-              <span data-toggle="tooltip" data-placement="right" title="{{ measure|goal_distance }}">
+              <span id="metric-hover" data-toggle="tooltip" data-placement="right" title="{{ measure|goal_distance }}">
                 {{ measure.value|floatformat:"0" }}%
               </span>
             </span>

--- a/templates/high_health.html
+++ b/templates/high_health.html
@@ -39,15 +39,17 @@
       <tbody>
         {% for metric in metrics %}
         <tr>
-          <td class="text-center eq" data-toggle="popover" data-trigger="hover"
-            title="{{ metric.metric.essential_question }}"
-            data-content="{{ metric.metric.essential_question.description }}">
-            {% if metric.metric.essential_question=="Priority" %}
+          {% if metric.metric.essential_question=="Priority" %}
+            <td class="text-center eq" data-toggle="popover" data-trigger="hover"
+              title="{{ metric.metric.essential_question }}"
+              data-content="{{ metric.metric.essential_question.description }}">
               P
-            {% else %}
-              -
-            {% end if %}
-          </td>
+            </td>
+          {% else %}
+            <td class="text-center eq" title="None">
+              --
+            </td>
+          {% end if %}
           <td style="min-width:240px">
             <i class="fas fa-info-circle text-primary pl-1 metric-def" data-toggle="popover" data-trigger="hover"
               title="{{ metric.metric }}" data-content="{{ metric.metric.definition }}"></i>

--- a/templates/high_health.html
+++ b/templates/high_health.html
@@ -46,7 +46,7 @@
               P
             </td>
           {% else %}
-            <td class="text-center eq" title="None">
+            <td class="text-center eq">
               --
             </td>
           {% endif %}

--- a/templatetags/high_health_helpers.py
+++ b/templatetags/high_health_helpers.py
@@ -16,11 +16,14 @@ def goal_format(measure):
     if measure.metric.frequency == "MoM":
         current_month = measure.month
         last_year = measure.year - 1
-        previous_outcome = Measure.objects.filter(
-            metric=measure.metric.id,
-            date__month=current_month,
-            date__year=last_year,
-            school=measure.school)[0].value
+        try:
+            previous_outcome = Measure.objects.filter(
+                metric=measure.metric.id,
+                date__month=current_month,
+                date__year=last_year,
+                school=measure.school)[0].value
+        except IndexError:
+            previous_outcome = measure.goal.previous_outcome
         if previous_outcome is None:
             previous_outcome = measure.goal.previous_outcome
         return mom_color_eval(measure, previous_outcome)

--- a/templatetags/high_health_helpers.py
+++ b/templatetags/high_health_helpers.py
@@ -50,6 +50,10 @@ def yoy_color_eval(measure, previous):
 
 
 def mom_color_eval(measure, previous):
+    # Filtering the % Staffed metric out of evaluation
+    if measure.metric.id == 36:
+        return "secondary"
+
     if measure.goal.goal_type.upper() == "ABOVE":
         if measure.value < previous:
             return "danger"


### PR DESCRIPTION
This PR is for two things:

1) Bringing back the "Priority" column in the HH table. Any metric that is designated to be a "Priority" will be marked with a "P". Non-priority metrics will be marked with a "--".

2) The new % Staffed metric will be bypassing the color evaluation logic and will automatically be grey. I am confident that this will happen with the HH table, however, it might not work for the modal charts that appear when clicking on the metric. If this doesn't work, then I will fix it. 