### PR TITLE
Removing 'school_levels' from context in HH view

### DIFF
--- a/high_health/views.py
+++ b/high_health/views.py
@@ -333,7 +333,6 @@ def high_health(request, school_level=None):
         "school_level": school_level,
         "schools": schools,
         "metrics": metrics(school_level),
-        "school_levels": SchoolLevel.objects.all(),
     }
     return render(request, "high_health.html", context)
 


### PR DESCRIPTION
The school_levels variable in the context from the high_helth function was overwriting the school_levels variable from  the navbar func in catalog.views. Removed "school_levels" from high health because it is not needed in the high health html and the navbar view should control the navbar across all pages.